### PR TITLE
Add logging category, replace configurations with grid configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,16 @@ Password:
 ```
 
 If "Password" is entered correctly, the user will be authenticated with iRODS, just like `pam_password`. The "Password" prompt is coming from the `pam_unix` module. For more information about this module, see the documentation in **man pam_unix**, or [https://linux.die.net/man/8/pam_unix](https://linux.die.net/man/8/pam_unix).
+
+## Logging
+
+The server-side plugin includes a logging category which can be configured in `server_config.json` under the `log_level` section like so:
+```javascript
+"log_level": {
+    // ... Other Log Categories ...
+
+    "pam_interactive_auth_plugin": "info",
+
+    // ... Other Log Categories ...
+},
+```

--- a/plugin/include/irods/private/pam/pam_interactive_plugin_logging_category.hpp
+++ b/plugin/include/irods/private/pam/pam_interactive_plugin_logging_category.hpp
@@ -1,0 +1,33 @@
+#ifndef IRODS_PAM_INTERACTIVE_AUTH_PLUGIN_LOGGING_CATEGORY_HPP
+#define IRODS_PAM_INTERACTIVE_AUTH_PLUGIN_LOGGING_CATEGORY_HPP
+
+#include <irods/irods_logger.hpp>
+
+// 1. Declare the custom category tag.
+//    This structure does not need to define a body.
+//    This tag allows the logger to locate data specific to the new category.
+struct pam_interactive_auth_plugin_logging_category;
+
+// 2. Specialize the logger configuration for the new category.
+//    This also defines the default configuration for the new category.
+namespace irods::experimental
+{
+    template <>
+    class log::logger_config<pam_interactive_auth_plugin_logging_category>
+    {
+        // This defines the name that will appear in the log under the "log_category" key.
+        // The "log_category" key defines where the message originated. Try to use a name
+        // that makes it easy for administrators to determine what produced the message.
+        static constexpr const char* name = "pam_interactive_auth_plugin";
+
+        // This is required since the fields above are private.
+        // This allows the logger to access and modify the configuration.
+        friend class logger<pam_interactive_auth_plugin_logging_category>;
+
+        // This is the current log level for the category. This also represents the initial
+        // log level. Use the "set_level()" function to adjust the level.
+        static inline log::level level = log::level::info;
+    };
+} // namespace irods::experimental
+
+#endif //IRODS_PAM_INTERACTIVE_AUTH_PLUGIN_LOGGING_CATEGORY_HPP


### PR DESCRIPTION
Addresses #28 
Addresses #33 

Logging category is based on the implementation in the S3 resource plugin repository. Willing to budge on category names, etc.

Generating random password with the database is based on the pam_password implementation. This is very similar to the one which was being used by the plugin.

`pam_password`-like flow continues to work. This is probably the last of what is needed to get some tests going for this repo.