### PR TITLE
[#6] Add test hook and configuration tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,16 @@ add_subdirectory(auth_check_wrapper)
 add_subdirectory(pam_handshake_auth_check)
 add_subdirectory(plugin)
 
+# Install the test file(s) alongside the server package.
+install(
+	FILES
+	${CMAKE_SOURCE_DIR}/packaging/test_irods_auth_plugin_pam_interactive.py
+	DESTINATION ${IRODS_HOME_DIRECTORY}/scripts/irods/test
+	PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
+	COMPONENT
+	"${project_component_part}-server"
+)
+
 set(PLUGIN_PACKAGE_NAME "irods-auth-plugin-pam-interactive")
 
 include(IrodsCPackCommon)
@@ -59,12 +69,14 @@ set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "The integrated Rule-Oriented Data System"
 set(CPACK_DEB_COMPONENT_INSTALL ON)
 set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS OFF)
 set(CPACK_DEBIAN_PACKAGE_CONTROL_STRICT_PERMISSION ON)
+set(CPACK_DEBIAN_PACKAGE_CONTROL_EXTRA "${CMAKE_SOURCE_DIR}/packaging/postinst;")
 set(CPACK_DEBIAN_FILE_NAME DEB-DEFAULT)
 
 set(CPACK_RPM_COMPONENT_INSTALL ON)
 set(CPACK_RPM_PACKAGE_LICENSE "BSD-3-Clause")
 set(CPACK_RPM_PACKAGE_AUTOREQ 0)
 set(CPACK_RPM_PACKAGE_AUTOPROV 0)
+set(CPACK_RPM_POST_INSTALL_SCRIPT_FILE "${CMAKE_SOURCE_DIR}/packaging/postinst")
 set(CPACK_RPM_FILE_NAME RPM-DEFAULT)
 
 string(TOUPPER "${project_component_part}-client" irods_plugin_package_client_component)

--- a/README.md
+++ b/README.md
@@ -61,3 +61,14 @@ The server-side plugin includes a logging category which can be configured in `s
     // ... Other Log Categories ...
 },
 ```
+
+## Testing
+
+Running the tests for this plugin should be familiar to those who have run tests for other iRODS plugins. This repository provides a test hook which is used by the iRODS Testing Environment. You can read about how to run plugin tests in the testing environment here: [https://github.com/irods/irods_testing_environment/?tab=readme-ov-file#run-irods-plugin-tests](https://github.com/irods/irods_testing_environment/?tab=readme-ov-file#run-irods-plugin-tests) Please note that using the `--use-ssl` option with the testing environment could cause tests to be skipped, so, as usual, please be mindful of which options are being used when running tests.
+
+In order to run tests aside from the tools provided by the testing environment, one can use the `run_tests.py` script provided by the iRODS server package:
+```bash
+python3 scripts/run_tests.py --run_specific_test test_irods_auth_plugin_pam_interactive
+```
+
+Use the `--help` option for `run_tests.py` to learn about other options. Please note that the test files are installed with the server package produced by this repository so it is assumed that a packaged installation is being used. If not, make sure that the test files in the `packaging` directory are placed alongside the other iRODS test files (for default packaged installations, this should be `/var/lib/irods/scripts/irods/test`).

--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ SSL is required to be configured for both the server and the client, even if the
 
 Set the `irods_authentication_scheme` in the client environment to `pam_interactive`.
 
+## Configuration
+
+This plugin uses the standard set of authentication configurations found in `R_GRID_CONFIGURATION`. You can read about these configurations here: [https://docs.irods.org/4.3.2/system_overview/configuration/#authentication-configuration](https://docs.irods.org/4.3.2/system_overview/configuration/#authentication-configuration)
+
 ### Example implementation: Replacement for `pam_password` authentication
 
 This plugin can be used as a drop-in replacement for `pam_password` (with the exception of some differing prompts). Here's how to set it up.

--- a/irods_consortium_continuous_integration_test_hook.py
+++ b/irods_consortium_continuous_integration_test_hook.py
@@ -1,0 +1,44 @@
+from __future__ import print_function
+
+import optparse
+import os
+import shutil
+import glob
+import irods_python_ci_utilities
+
+def main():
+	parser = optparse.OptionParser()
+	parser.add_option('--output_root_directory')
+	parser.add_option('--built_packages_root_directory')
+	parser.add_option('--test', metavar='dotted name')
+	parser.add_option('--skip-setup', action='store_false', dest='do_setup', default=True)
+	options, _ = parser.parse_args()
+
+	built_packages_root_directory = options.built_packages_root_directory
+	package_suffix = irods_python_ci_utilities.get_package_suffix()
+	os_specific_directory = irods_python_ci_utilities.append_os_specific_directory(built_packages_root_directory)
+
+	if options.do_setup:
+		# TODO(#42): set up required PAM user and PAM stacks for tests
+
+		irods_python_ci_utilities.install_os_packages_from_files(
+			glob.glob(os.path.join(os_specific_directory,
+					  f'irods-auth-plugin-pam-interactive*.{package_suffix}')
+			)
+		)
+
+	test = options.test or 'test_irods_auth_plugin_pam_interactive'
+
+	try:
+		test_output_file = 'log/test_output.log'
+		irods_python_ci_utilities.subprocess_get_output(['sudo', 'su', '-', 'irods', '-c',
+			f'python3 scripts/run_tests.py --xml_output --run_s {test} 2>&1 | tee {test_output_file}; exit $PIPESTATUS'],
+			check_rc=True)
+	finally:
+		output_root_directory = options.output_root_directory
+		if output_root_directory:
+			irods_python_ci_utilities.gather_files_satisfying_predicate('/var/lib/irods/log', output_root_directory, lambda x: True)
+			shutil.copy('/var/lib/irods/log/test_output.log', output_root_directory)
+
+if __name__ == '__main__':
+	main()

--- a/packaging/postinst
+++ b/packaging/postinst
@@ -1,0 +1,13 @@
+if [ -f /etc/irods/service_account.config ] ; then
+  . /etc/irods/service_account.config
+else
+  IRODS_SERVICE_ACCOUNT_NAME=`stat --format "%U" /var/lib/irods`
+  IRODS_SERVICE_GROUP_NAME=`stat --format "%G" /var/lib/irods`
+fi
+
+
+chown $IRODS_SERVICE_ACCOUNT_NAME:$IRODS_SERVICE_GROUP_NAME /var/lib/irods
+chown $IRODS_SERVICE_ACCOUNT_NAME:$IRODS_SERVICE_GROUP_NAME /var/lib/irods/scripts
+chown $IRODS_SERVICE_ACCOUNT_NAME:$IRODS_SERVICE_GROUP_NAME /var/lib/irods/scripts/irods
+chown $IRODS_SERVICE_ACCOUNT_NAME:$IRODS_SERVICE_GROUP_NAME /var/lib/irods/scripts/irods/test
+chown $IRODS_SERVICE_ACCOUNT_NAME:$IRODS_SERVICE_GROUP_NAME /var/lib/irods/scripts/irods/test/test_irods_auth_plugin_pam_interactive.py

--- a/packaging/test_irods_auth_plugin_pam_interactive.py
+++ b/packaging/test_irods_auth_plugin_pam_interactive.py
@@ -1,0 +1,669 @@
+from __future__ import print_function
+
+import copy
+import os
+import unittest
+
+from . import session
+from .. import lib
+from .. import test
+from ..configuration import IrodsConfig
+from ..controller import IrodsController
+from ..core_file import temporary_core_file
+
+
+@unittest.skipIf(test.settings.USE_SSL, 'SSL is set up in these tests, so just skip if SSL is enabled already.')
+@unittest.skipIf(test.settings.RUN_IN_TOPOLOGY, 'SSL configuration cannot be applied to all servers from the tests.')
+class test_configurations(unittest.TestCase):
+	plugin_name = IrodsConfig().default_rule_engine_plugin
+
+	@staticmethod
+	def generate_default_ssl_files(ssl_directory=None, numbits_for_genrsa=2048):
+		ssl_directory = ssl_directory or os.path.join(IrodsConfig().irods_directory, 'test')
+
+		server_key_path = os.path.join(ssl_directory, 'server.key')
+		chain_pem_path = os.path.join(ssl_directory, 'chain.pem')
+		dhparams_pem_path = os.path.join(ssl_directory, 'dhparams.pem')
+
+		lib.execute_command(['openssl', 'genrsa', '-out', server_key_path, str(numbits_for_genrsa)])
+		lib.execute_command(
+			['openssl', 'req', '-batch', '-new', '-x509', '-key', server_key_path, '-out', chain_pem_path, '-days', '365'])
+		lib.execute_command(['openssl', 'dhparam', '-2', '-out', dhparams_pem_path, str(numbits_for_genrsa)])
+
+		return (server_key_path, chain_pem_path, dhparams_pem_path)
+
+	@staticmethod
+	def make_dict_for_ssl_client_environment(server_key_path, chain_pem_path, dhparams_pem_path, ca_certificate_path=None):
+		ca_certificate_path = ca_certificate_path or chain_pem_path
+		return {
+			'irods_client_server_negotiation': 'request_server_negotiation',
+			'irods_client_server_policy': 'CS_NEG_REQUIRE',
+			'irods_ssl_certificate_chain_file': chain_pem_path,
+			'irods_ssl_certificate_key_file': server_key_path,
+			'irods_ssl_dh_params_file': dhparams_pem_path,
+			'irods_ssl_ca_certificate_file': ca_certificate_path,
+			'irods_ssl_verify_server': 'none'
+		}
+
+	@staticmethod
+	def get_pep_for_ssl(plugin_name):
+		import textwrap
+
+		return {
+			'irods_rule_engine_plugin-irods_rule_language': textwrap.dedent('''
+				acPreConnect(*OUT) {
+					*OUT = 'CS_NEG_REQUIRE';
+				}
+			'''),
+			'irods_rule_engine_plugin-python': textwrap.dedent('''
+				def acPreConnect(rule_args, callback, rei):
+					rule_args[0] = 'CS_NEG_REQUIRE'
+			''')
+		}[plugin_name]
+
+	@classmethod
+	def setUpClass(self):
+		self.admin = session.mkuser_and_return_session('rodsadmin', 'otherrods', 'rods', lib.get_hostname())
+
+		cfg = lib.open_and_load_json(
+			os.path.join(IrodsConfig().irods_directory, 'test', 'test_framework_configuration.json'))
+		self.auth_user = cfg['irods_authuser_name']
+		self.auth_pass = cfg['irods_authuser_password']
+
+		# Requires existence of OS account 'irodsauthuser' with password ';=iamnotasecret'
+		try:
+			import pwd
+			pwd.getpwnam(self.auth_user)
+
+		except KeyError:
+			# This is a requirement in order to run these tests and running the tests is required for our test suite, so
+			# we always fail here when the prerequisites are not being met on the test-running host.
+			raise EnvironmentError(
+				'OS user "{}" with password "{}" must exist in order to run these tests.'.format(
+				self.auth_user, self.auth_pass))
+
+		self.auth_session = session.mkuser_and_return_session('rodsuser', self.auth_user, self.auth_pass, lib.get_hostname())
+		self.service_account_environment_file_path = os.path.join(
+			os.path.expanduser('~'), '.irods', 'irods_environment.json')
+
+		self.server_key_path, self.chain_pem_path, self.dhparams_pem_path = test_configurations.generate_default_ssl_files()
+		self.authentication_scheme = 'pam_interactive'
+		self.configuration_namespace = 'authentication'
+
+	@classmethod
+	def tearDownClass(self):
+		self.auth_session.__exit__()
+
+		for filename in [self.chain_pem_path, self.server_key_path, self.dhparams_pem_path]:
+			if os.path.exists(filename):
+				os.unlink(filename)
+
+		self.admin.assert_icommand(['iadmin', 'rmuser', self.auth_session.username])
+		self.admin.__exit__()
+		with session.make_session_for_existing_admin() as admin_session:
+			admin_session.assert_icommand(['iadmin', 'rmuser', self.admin.username])
+
+	def do_test_invalid_password_time_configurations(self, _option_name):
+		# Stash away the original configuration for later...
+		original_config = self.admin.assert_icommand(
+				['iadmin', 'get_grid_configuration', self.configuration_namespace, _option_name], 'STDOUT')[1].strip()
+
+		IrodsController().stop()
+
+		auth_session_env_backup = copy.deepcopy(self.auth_session.environment_file_contents)
+		admin_session_env_backup = copy.deepcopy(self.admin.environment_file_contents)
+		try:
+			service_account_environment_file_path = os.path.join(
+				os.path.expanduser('~'), '.irods', 'irods_environment.json')
+			with lib.file_backed_up(service_account_environment_file_path):
+				client_update = test_configurations.make_dict_for_ssl_client_environment(
+					self.server_key_path, self.chain_pem_path, self.dhparams_pem_path)
+
+				lib.update_json_file_from_dict(service_account_environment_file_path, client_update)
+
+				self.admin.environment_file_contents.update(client_update)
+
+				client_update['irods_authentication_scheme'] = self.authentication_scheme
+				self.auth_session.environment_file_contents.update(client_update)
+
+				with temporary_core_file() as core:
+					core.add_rule(test_configurations.get_pep_for_ssl(self.plugin_name))
+
+					IrodsController().start()
+
+					# Make sure the settings applied correctly...
+					self.admin.assert_icommand(
+						['iadmin', 'get_grid_configuration', self.configuration_namespace, _option_name],
+						'STDOUT', original_config)
+
+					self.auth_session.assert_icommand(
+						['iinit'], 'STDOUT', 'Password:', input=f'{self.auth_session.password}\n')
+					self.auth_session.assert_icommand(["ils"], 'STDOUT', self.auth_session.session_collection)
+
+					for option_value in [' ', 'nope', str(-1), str(18446744073709552000), str(-18446744073709552000)]:
+						with self.subTest(f'test with value [{option_value}]'):
+							self.admin.assert_icommand(
+								['iadmin', 'set_grid_configuration', '--', self.configuration_namespace, _option_name, option_value])
+
+							# These invalid configurations will not cause any errors, but default values will be used.
+							self.auth_session.assert_icommand(
+								['iinit'], 'STDOUT', 'Password:', input=f'{self.auth_session.password}\n')
+							self.auth_session.assert_icommand(["ils"], 'STDOUT', self.auth_session.session_collection)
+
+		finally:
+			self.auth_session.environment_file_contents = auth_session_env_backup
+			self.admin.environment_file_contents = admin_session_env_backup
+
+			IrodsController().restart()
+
+			self.admin.assert_icommand(
+				['iadmin', 'set_grid_configuration', self.configuration_namespace, _option_name, original_config])
+
+	def test_invalid_password_max_time(self):
+		self.do_test_invalid_password_time_configurations('password_max_time')
+
+	def test_invalid_password_min_time(self):
+		self.do_test_invalid_password_time_configurations('password_min_time')
+
+	def test_password_max_time_less_than_password_min_time_makes_ttl_constraints_unsatisfiable(self):
+		min_time_option_name = 'password_min_time'
+		max_time_option_name = 'password_max_time'
+
+		# Stash away the original configuration for later...
+		original_min_time = self.admin.assert_icommand(
+			['iadmin', 'get_grid_configuration', self.configuration_namespace, min_time_option_name], 'STDOUT')[1].strip()
+
+		original_max_time = self.admin.assert_icommand(
+			['iadmin', 'get_grid_configuration', self.configuration_namespace, max_time_option_name], 'STDOUT')[1].strip()
+
+		IrodsController().stop()
+
+		auth_session_env_backup = copy.deepcopy(self.auth_session.environment_file_contents)
+		admin_session_env_backup = copy.deepcopy(self.admin.environment_file_contents)
+		try:
+			service_account_environment_file_path = os.path.join(
+				os.path.expanduser('~'), '.irods', 'irods_environment.json')
+			with lib.file_backed_up(service_account_environment_file_path):
+				client_update = test_configurations.make_dict_for_ssl_client_environment(
+					self.server_key_path, self.chain_pem_path, self.dhparams_pem_path)
+
+				lib.update_json_file_from_dict(service_account_environment_file_path, client_update)
+
+				self.admin.environment_file_contents.update(client_update)
+
+				client_update['irods_authentication_scheme'] = self.authentication_scheme
+				self.auth_session.environment_file_contents.update(client_update)
+
+				with temporary_core_file() as core:
+					core.add_rule(test_configurations.get_pep_for_ssl(self.plugin_name))
+
+					IrodsController().start()
+
+					# Make sure the settings applied correctly...
+					self.admin.assert_icommand(
+						['iadmin', 'get_grid_configuration', self.configuration_namespace, max_time_option_name],
+						'STDOUT', original_max_time)
+
+					# Try a few different values here that are in the range of overall acceptable values:
+					#	 - 2 hours allows us to go up OR down by 1 hour (boundary case).
+					#	 - 336 hours is 1209600 seconds (or 2 weeks) which is the default maximum allowed TTL value.
+					for base_ttl_in_hours in [2, 336]:
+						with self.subTest(f'test with TTL of [{base_ttl_in_hours}] hours'):
+							base_ttl_in_seconds = base_ttl_in_hours * 3600
+
+							option_value = str(base_ttl_in_seconds + 10)
+							self.admin.assert_icommand(
+								['iadmin', 'set_grid_configuration', self.configuration_namespace, min_time_option_name, option_value])
+
+							# Set password_max_time to a value less than the password_min_time.
+							option_value = str(base_ttl_in_seconds - 10)
+							self.admin.assert_icommand(
+								['iadmin', 'set_grid_configuration', self.configuration_namespace, max_time_option_name, option_value])
+
+							# Note: The min/max check does not occur when no TTL parameter is passed. If no TTL is
+							# passed, the minimum password lifetime is used for the TTL. Therefore, to test TTL lifetime
+							# boundaries, we must pass TTL explicitly for each test.
+
+							# This is lower than the minimum and higher than the maximum. The TTL is invalid.
+							self.auth_session.assert_icommand(
+								['iinit', '--ttl', str(base_ttl_in_hours)],
+								 'STDERR', 'PAM_AUTH_PASSWORD_INVALID_TTL', input=f'{self.auth_session.password}\n')
+
+							# This is lower than the maximum but also lower than the minimum. The TTL is invalid.
+							self.auth_session.assert_icommand(
+								['iinit', '--ttl', str(base_ttl_in_hours - 1)],
+								 'STDERR', 'PAM_AUTH_PASSWORD_INVALID_TTL', input=f'{self.auth_session.password}\n')
+
+							# This is higher than the minimum but also higher than the maximum. The TTL is invalid.
+							self.auth_session.assert_icommand(
+								['iinit', '--ttl', str(base_ttl_in_hours + 1)],
+								 'STDERR', 'PAM_AUTH_PASSWORD_INVALID_TTL', input=f'{self.auth_session.password}\n')
+
+					# Restore grid configuration and try again, with success.
+					self.admin.assert_icommand(
+						['iadmin', 'set_grid_configuration', self.configuration_namespace, max_time_option_name, original_max_time])
+					self.admin.assert_icommand(
+						['iadmin', 'set_grid_configuration', self.configuration_namespace, min_time_option_name, original_min_time])
+
+					self.auth_session.assert_icommand(
+						['iinit', '--ttl', str(1)], 'STDOUT', input=f'{self.auth_session.password}\n')
+					self.auth_session.assert_icommand(["ils"], 'STDOUT', self.auth_session.session_collection)
+
+		finally:
+			self.auth_session.environment_file_contents = auth_session_env_backup
+			self.admin.environment_file_contents = admin_session_env_backup
+
+			IrodsController().restart()
+
+			self.admin.assert_icommand(
+				['iadmin', 'set_grid_configuration', self.configuration_namespace, max_time_option_name, original_max_time])
+			self.admin.assert_icommand(
+				['iadmin', 'set_grid_configuration', self.configuration_namespace, min_time_option_name, original_min_time])
+
+			IrodsController().restart()
+
+	def test_password_expires_appropriately_based_on_grid_configuration_value(self):
+		import time
+
+		min_time_option_name = 'password_min_time'
+		max_time_option_name = 'password_max_time'
+
+		# Stash away the original configuration for later...
+		original_min_time = self.admin.assert_icommand(
+			['iadmin', 'get_grid_configuration', self.configuration_namespace, min_time_option_name], 'STDOUT')[1].strip()
+
+		original_max_time = self.admin.assert_icommand(
+			['iadmin', 'get_grid_configuration', self.configuration_namespace, max_time_option_name], 'STDOUT')[1].strip()
+
+		IrodsController().stop()
+
+		auth_session_env_backup = copy.deepcopy(self.auth_session.environment_file_contents)
+		admin_session_env_backup = copy.deepcopy(self.admin.environment_file_contents)
+		try:
+			service_account_environment_file_path = os.path.join(
+				os.path.expanduser('~'), '.irods', 'irods_environment.json')
+			with lib.file_backed_up(service_account_environment_file_path):
+				client_update = test_configurations.make_dict_for_ssl_client_environment(
+					self.server_key_path, self.chain_pem_path, self.dhparams_pem_path)
+
+				lib.update_json_file_from_dict(service_account_environment_file_path, client_update)
+
+				self.admin.environment_file_contents.update(client_update)
+
+				client_update['irods_authentication_scheme'] = self.authentication_scheme
+				self.auth_session.environment_file_contents.update(client_update)
+
+				with temporary_core_file() as core:
+					core.add_rule(test_configurations.get_pep_for_ssl(self.plugin_name))
+
+					IrodsController().start()
+
+					# Make sure the settings applied correctly...
+					self.admin.assert_icommand(
+						['iadmin', 'get_grid_configuration', self.configuration_namespace, max_time_option_name],
+						'STDOUT', original_max_time)
+
+					# When no TTL is specified, the default value is the minimum password lifetime as configured in
+					# R_GRID_CONFIGURATION. This value should be higher than 3 seconds to ensure steps in the test
+					# have enough time to complete.
+					ttl = 4
+					self.assertGreater(ttl, 3)
+					option_value = str(ttl)
+					self.admin.assert_icommand(
+						['iadmin', 'set_grid_configuration', self.configuration_namespace, min_time_option_name, option_value])
+
+					# Authenticate and run a command...
+					self.auth_session.assert_icommand(
+						['iinit'], 'STDOUT', 'Password:', input=f'{self.auth_session.password}\n')
+
+					self.auth_session.assert_icommand(["ils"], 'STDOUT', self.auth_session.session_collection)
+
+					# Sleep until the password is expired...
+					time.sleep(ttl + 1)
+
+					# Password should be expired now...
+					self.auth_session.assert_icommand(["ils"], 'STDERR', 'CAT_PASSWORD_EXPIRED: failed to perform request')
+
+					# ...and stays expired.
+					# TODO: irods/irods#7344 - This should emit a better error message.
+					self.auth_session.assert_icommand(["ils"], 'STDERR', 'CAT_INVALID_AUTHENTICATION: failed to perform request')
+
+					# Restore grid configuration and try again, with success.
+					self.admin.assert_icommand(
+						['iadmin', 'set_grid_configuration', self.configuration_namespace, max_time_option_name, original_max_time])
+					self.admin.assert_icommand(
+						['iadmin', 'set_grid_configuration', self.configuration_namespace, min_time_option_name, original_min_time])
+
+					self.auth_session.assert_icommand(['iinit'], 'STDOUT', input=f'{self.auth_session.password}\n')
+					self.auth_session.assert_icommand(["ils"], 'STDOUT', self.auth_session.session_collection)
+
+		finally:
+			self.auth_session.environment_file_contents = auth_session_env_backup
+			self.admin.environment_file_contents = admin_session_env_backup
+
+			IrodsController().restart()
+
+			self.admin.assert_icommand(
+				['iadmin', 'set_grid_configuration', self.configuration_namespace, max_time_option_name, original_max_time])
+			self.admin.assert_icommand(
+				['iadmin', 'set_grid_configuration', self.configuration_namespace, min_time_option_name, original_min_time])
+
+			# Re-authenticate as the session user to make sure things can be cleaned up.
+			self.auth_session.assert_icommand(
+				['iinit'], 'STDOUT', 'iRODS password', input=f'{self.auth_session.password}\n')
+
+	def test_password_extend_lifetime_set_to_true_extends_other_authentications_past_expiration(self):
+		import time
+
+		min_time_option_name = 'password_min_time'
+		extend_lifetime_option_name = 'password_extend_lifetime'
+
+		# Stash away the original configuration for later...
+		original_min_time = self.admin.assert_icommand(
+			['iadmin', 'get_grid_configuration', self.configuration_namespace, min_time_option_name],
+			'STDOUT')[1].strip()
+
+		original_extend_lifetime = self.admin.assert_icommand(
+			['iadmin', 'get_grid_configuration', self.configuration_namespace, extend_lifetime_option_name],
+			'STDOUT')[1].strip()
+
+		# Set password_extend_lifetime to 1 so that the same randomly generated password is used for all sessions.
+		self.admin.assert_icommand(
+			['iadmin', 'set_grid_configuration', self.configuration_namespace, extend_lifetime_option_name, '1'])
+
+		# Make a new session of the existing auth_user. The data is "managed" in the session, so the session
+		# collection shall be shared with the other session.
+		temp_auth_session = session.make_session_for_existing_user(
+			self.auth_user, self.auth_pass, lib.get_hostname(), self.auth_session.zone_name)
+		temp_auth_session.assert_icommand(['icd', self.auth_session.session_collection])
+
+		IrodsController().stop()
+
+		auth_session_env_backup = copy.deepcopy(self.auth_session.environment_file_contents)
+		admin_session_env_backup = copy.deepcopy(self.admin.environment_file_contents)
+
+		try:
+			service_account_environment_file_path = os.path.join(
+				os.path.expanduser('~'), '.irods', 'irods_environment.json')
+			with lib.file_backed_up(service_account_environment_file_path):
+				client_update = test_configurations.make_dict_for_ssl_client_environment(
+					self.server_key_path, self.chain_pem_path, self.dhparams_pem_path)
+
+				lib.update_json_file_from_dict(service_account_environment_file_path, client_update)
+
+				self.admin.environment_file_contents.update(client_update)
+
+				client_update['irods_authentication_scheme'] = self.authentication_scheme
+				self.auth_session.environment_file_contents.update(client_update)
+				temp_auth_session.environment_file_contents.update(client_update)
+
+				with temporary_core_file() as core:
+					core.add_rule(test_configurations.get_pep_for_ssl(self.plugin_name))
+
+					IrodsController().start()
+
+					# Make sure the settings applied correctly...
+					self.admin.assert_icommand(
+						['iadmin', 'get_grid_configuration', self.configuration_namespace, extend_lifetime_option_name],
+						'STDOUT', '1')
+
+					# Set the minimum time to a very short value so that the password expires in a reasonable amount of
+					# time for testing purposes. This value should be higher than 3 seconds to ensure steps in the test
+					# have enough time to complete.
+					ttl = 4
+					self.assertGreater(ttl, 3)
+					option_value = str(ttl)
+					self.admin.assert_icommand(
+						['iadmin', 'set_grid_configuration', self.configuration_namespace, min_time_option_name, option_value])
+
+					# Authenticate with both sessions and run a command...
+					self.auth_session.assert_icommand(
+						['iinit'], 'STDOUT', 'Password:', input=f'{self.auth_session.password}\n')
+					temp_auth_session.assert_icommand(
+						['iinit'], 'STDOUT', 'Password:', input=f'{self.auth_session.password}\n')
+
+					self.auth_session.assert_icommand(["ils"], 'STDOUT', self.auth_session.session_collection)
+					temp_auth_session.assert_icommand(["ils"], 'STDOUT', self.auth_session.session_collection)
+
+					# Sleep until just before password is expired...
+					time.sleep(ttl - 1)
+
+					# Re-authenticate as one of the sessions such that the random password lifetime is extended. This
+					# will allow the other session to continue without re-authenticating.
+					self.auth_session.assert_icommand(
+						['iinit'], 'STDOUT', 'Password:', input=f'{self.auth_session.password}\n')
+
+					# We want to sleep 1 second past the timeout (ttl + 1) to ensure that the original expiration time
+					# has passed. We already slept ttl - 1 seconds, so the remaining time is calculated like this:
+					# remaining_sleep_time = total_time_to_sleep - time_already_slept = (ttl + 1) - (ttl - 1) = 2
+					time.sleep(2)
+
+					# Run a command as the other session to show that the existing password is still valid.
+					temp_auth_session.assert_icommand(["ils"], 'STDOUT', self.auth_session.session_collection)
+
+					# The re-authenticated session should also be able to run commands, of course.
+					self.auth_session.assert_icommand(["ils"], 'STDOUT', self.auth_session.session_collection)
+
+					# Sleep again to let the password time out.
+					time.sleep(ttl + 1)
+
+					# Password should be expired now...
+					temp_auth_session.assert_icommand(
+						["ils"], 'STDERR', 'CAT_PASSWORD_EXPIRED: failed to perform request')
+					# The sessions are using the same password, so the second response will be different
+					# TODO: irods/irods#7344 - This should emit a better error message.
+					self.auth_session.assert_icommand(
+						["ils"], 'STDERR', 'CAT_INVALID_AUTHENTICATION: failed to perform request')
+
+		finally:
+			temp_auth_session.environment_file_contents = auth_session_env_backup
+			self.auth_session.environment_file_contents = auth_session_env_backup
+			self.admin.environment_file_contents = admin_session_env_backup
+
+			IrodsController().restart()
+
+			self.admin.assert_icommand(
+				['iadmin', 'set_grid_configuration', self.configuration_namespace, extend_lifetime_option_name, original_extend_lifetime])
+			self.admin.assert_icommand(
+				['iadmin', 'set_grid_configuration', self.configuration_namespace, min_time_option_name, original_min_time])
+
+			# Re-authenticate as the session user to make sure things can be cleaned up.
+			self.auth_session.assert_icommand(
+				['iinit'], 'STDOUT', 'iRODS password', input=f'{self.auth_session.password}\n')
+
+	def test_password_extend_lifetime_set_to_false_invalidates_other_authentications_on_expiration(self):
+		import time
+
+		min_time_option_name = 'password_min_time'
+		extend_lifetime_option_name = 'password_extend_lifetime'
+
+		# Stash away the original configuration for later...
+		original_min_time = self.admin.assert_icommand(
+			['iadmin', 'get_grid_configuration', self.configuration_namespace, min_time_option_name],
+			'STDOUT')[1].strip()
+
+		original_extend_lifetime = self.admin.assert_icommand(
+			['iadmin', 'get_grid_configuration', self.configuration_namespace, extend_lifetime_option_name],
+			'STDOUT')[1].strip()
+
+		# Set password_extend_lifetime to 1 so that the same randomly generated password is used for all sessions.
+		self.admin.assert_icommand(
+			['iadmin', 'set_grid_configuration', self.configuration_namespace, extend_lifetime_option_name, '1'])
+
+		# Make a new session of the existing auth_user. The data is "managed" in the session, so the session
+		# collection shall be shared with the other session.
+		temp_auth_session = session.make_session_for_existing_user(
+			self.auth_user, self.auth_pass, lib.get_hostname(), self.auth_session.zone_name)
+		temp_auth_session.assert_icommand(['icd', self.auth_session.session_collection])
+
+		IrodsController().stop()
+
+		auth_session_env_backup = copy.deepcopy(self.auth_session.environment_file_contents)
+		admin_session_env_backup = copy.deepcopy(self.admin.environment_file_contents)
+
+		try:
+			service_account_environment_file_path = os.path.join(
+				os.path.expanduser('~'), '.irods', 'irods_environment.json')
+			with lib.file_backed_up(service_account_environment_file_path):
+				client_update = test_configurations.make_dict_for_ssl_client_environment(
+					self.server_key_path, self.chain_pem_path, self.dhparams_pem_path)
+
+				lib.update_json_file_from_dict(service_account_environment_file_path, client_update)
+
+				self.admin.environment_file_contents.update(client_update)
+
+				client_update['irods_authentication_scheme'] = self.authentication_scheme
+				self.auth_session.environment_file_contents.update(client_update)
+				temp_auth_session.environment_file_contents.update(client_update)
+
+				with temporary_core_file() as core:
+					core.add_rule(test_configurations.get_pep_for_ssl(self.plugin_name))
+
+					IrodsController().start()
+
+					# Make sure the settings applied correctly...
+					self.admin.assert_icommand(
+						['iadmin', 'get_grid_configuration', self.configuration_namespace, extend_lifetime_option_name],
+						'STDOUT', '1')
+
+					# Set the minimum time to a very short value so that the password expires in a reasonable amount of
+					# time for testing purposes. This value should be higher than 3 seconds to ensure steps in the test
+					# have enough time to complete.
+					ttl = 4
+					self.assertGreater(ttl, 3)
+					option_value = str(ttl)
+					self.admin.assert_icommand(
+						['iadmin', 'set_grid_configuration', self.configuration_namespace, min_time_option_name, option_value])
+
+					# Authenticate with both sessions and run a command...
+					self.auth_session.assert_icommand(
+						['iinit'], 'STDOUT', 'Password:', input=f'{self.auth_session.password}\n')
+					temp_auth_session.assert_icommand(
+						['iinit'], 'STDOUT', 'Password:', input=f'{temp_auth_session.password}\n')
+
+					self.auth_session.assert_icommand(["ils"], 'STDOUT', self.auth_session.session_collection)
+					temp_auth_session.assert_icommand(["ils"], 'STDOUT', self.auth_session.session_collection)
+
+					# Disable password_extend_lifetime so that on the next authentication, the expiration time of the
+					# existing password will not be extended.
+					self.admin.assert_icommand(
+						['iadmin', 'set_grid_configuration', self.configuration_namespace, extend_lifetime_option_name, '0'])
+
+					# Sleep until just before password is expired...
+					time.sleep(ttl - 1)
+
+					# Re-authenticate as one of the sessions - the random password lifetime will not be extended for
+					# either session.
+					self.auth_session.assert_icommand(
+						['iinit'], 'STDOUT', 'Password:', input=f'{self.auth_session.password}\n')
+
+					# We want to sleep 1 second past the timeout (ttl + 1) to ensure that the original expiration time
+					# has passed. We already slept ttl - 1 seconds, so the remaining time is calculated like this:
+					# remaining_sleep_time = total_time_to_sleep - time_already_slept = (ttl + 1) - (ttl - 1) = 2
+					time.sleep(2)
+
+					# Password should be expired for both sessions despite one having re-authenticated past the
+					# expiry time.
+					out, err, rc = temp_auth_session.run_icommand('ils')
+					self.assertEqual('', out)
+					# #7344 - This should always return CAT_PASSWORD_EXPIRED, but sometimes it returns
+					# CAT_INVALID_AUTHENTICATION. This should be made more consistent.
+					self.assertTrue(
+						'CAT_PASSWORD_EXPIRED: failed to perform request' in err or
+						'CAT_INVALID_AUTHENTICATION: failed to perform request' in err)
+					self.assertNotEqual(0, rc)
+					# The sessions are using the same password, so the second response will be different
+					# TODO: irods/irods#7344 - This should emit a better error message.
+					self.auth_session.assert_icommand(
+						["ils"], 'STDERR', 'CAT_INVALID_AUTHENTICATION: failed to perform request')
+
+		finally:
+			temp_auth_session.environment_file_contents = auth_session_env_backup
+			self.auth_session.environment_file_contents = auth_session_env_backup
+			self.admin.environment_file_contents = admin_session_env_backup
+
+			IrodsController().restart()
+
+			self.admin.assert_icommand(
+				['iadmin', 'set_grid_configuration', self.configuration_namespace, extend_lifetime_option_name, original_extend_lifetime])
+			self.admin.assert_icommand(
+				['iadmin', 'set_grid_configuration', self.configuration_namespace, min_time_option_name, original_min_time])
+
+			# Re-authenticate as the session user to make sure things can be cleaned up.
+			self.auth_session.assert_icommand(
+				['iinit'], 'STDOUT', 'iRODS password', input=f'{self.auth_session.password}\n')
+
+	def test_password_max_time_can_exceed_1209600__issue_3742_5096(self):
+		# Note: This does NOT test the TTL as this would require waiting for the password to expire (2 weeks + 1 hour).
+		# The test is meant to ensure that a TTL greater than 1209600 is allowed with iinit when it is so configured.
+
+		max_time_option_name = 'password_max_time'
+
+		# Stash away the original configuration for later...
+		original_max_time = self.admin.assert_icommand(
+			['iadmin', 'get_grid_configuration', self.configuration_namespace, max_time_option_name], 'STDOUT')[1].strip()
+
+		IrodsController().stop()
+
+		auth_session_env_backup = copy.deepcopy(self.auth_session.environment_file_contents)
+		admin_session_env_backup = copy.deepcopy(self.admin.environment_file_contents)
+		try:
+			service_account_environment_file_path = os.path.join(
+				os.path.expanduser('~'), '.irods', 'irods_environment.json')
+			with lib.file_backed_up(service_account_environment_file_path):
+				client_update = test_configurations.make_dict_for_ssl_client_environment(
+					self.server_key_path, self.chain_pem_path, self.dhparams_pem_path)
+
+				lib.update_json_file_from_dict(service_account_environment_file_path, client_update)
+
+				self.admin.environment_file_contents.update(client_update)
+
+				client_update['irods_authentication_scheme'] = self.authentication_scheme
+				self.auth_session.environment_file_contents.update(client_update)
+
+				with temporary_core_file() as core:
+					core.add_rule(test_configurations.get_pep_for_ssl(self.plugin_name))
+
+					IrodsController().start()
+
+					# The test value is 2 hours more than the default in order to try a TTL value 1 greater and 1 less
+					# than the configured password_max_time while still remaining above 1209600 to show that there is
+					# nothing special about that value.
+					base_ttl_in_hours = 336 + 2
+					base_ttl_in_seconds = base_ttl_in_hours * 3600
+
+					# Set password_max_time to the value for the test.
+					option_value = str(base_ttl_in_seconds)
+					self.admin.assert_icommand(
+						['iadmin', 'set_grid_configuration', self.configuration_namespace, max_time_option_name, option_value])
+
+					# Note: The min/max check does not occur when no TTL parameter is passed. If no TTL is passed, the
+					# minimum password lifetime is used for the TTL. Therefore, to test TTL lifetime boundaries, we must
+					# pass TTL explicitly for each test.
+
+					# TTL value is higher than the maximum. The TTL is invalid.
+					self.auth_session.assert_icommand(
+						['iinit', '--ttl', str(base_ttl_in_hours + 1)],
+						 'STDERR', 'PAM_AUTH_PASSWORD_INVALID_TTL',
+						 input=f'{self.auth_session.password}\n')
+
+					# TTL value is lower than the maximum. The TTL is valid.
+					self.auth_session.assert_icommand(
+						 ['iinit', '--ttl', str(base_ttl_in_hours - 1)],
+						 'STDOUT', 'Password:',
+						 input=f'{self.auth_session.password}\n')
+ 
+					# TTL value is equal to the maximum. The TTL is valid.
+					self.auth_session.assert_icommand(
+						 ['iinit', '--ttl', str(base_ttl_in_hours)],
+						 'STDOUT', 'Password:',
+						 input=f'{self.auth_session.password}\n')
+
+		finally:
+			self.auth_session.environment_file_contents = auth_session_env_backup
+			self.admin.environment_file_contents = admin_session_env_backup
+
+			IrodsController().restart()
+
+			self.admin.assert_icommand(
+				['iadmin', 'set_grid_configuration', self.configuration_namespace, max_time_option_name, original_max_time])


### PR DESCRIPTION
Addresses #6

Tests are a copy of the file `test_pam_password_authentication.py` from the main iRODS repo, with the authentication scheme tweaked to be `pam_interactive` instead of `pam_password` and the expected prompts from `iinit` were changed to match the out-of-the-box `pam_unix` password prompt.

CMake and packaging efforts were based on existing plugins, so... please pay special attention to those areas to make sure that looks right.

Server package for focal:
```
$ dpkg -c irods-auth-plugin-pam-interactive-server_0.1.0-0+4.3.3~focal_amd64.deb 
drwxr-xr-x root/root         0 2024-08-05 11:19 ./usr/
drwxr-xr-x root/root         0 2024-08-05 11:19 ./usr/lib/
drwxr-xr-x root/root         0 2024-08-05 11:19 ./usr/lib/irods/
drwxr-xr-x root/root         0 2024-08-05 11:19 ./usr/lib/irods/plugins/
drwxr-xr-x root/root         0 2024-08-05 11:19 ./usr/lib/irods/plugins/auth/
-rw-r--r-- root/root   3136312 2024-08-05 11:12 ./usr/lib/irods/plugins/auth/libirods_auth_plugin-pam_interactive_server.so
-rwsr-xr-x root/root     98672 2024-08-05 11:12 ./usr/lib/irods/plugins/auth/pam_handshake_auth_check
drwxr-xr-x root/root         0 2024-08-05 11:19 ./var/
drwxr-xr-x root/root         0 2024-08-05 11:19 ./var/lib/
drwxr-xr-x root/root         0 2024-08-05 11:19 ./var/lib/irods/
drwxr-xr-x root/root         0 2024-08-05 11:19 ./var/lib/irods/scripts/
drwxr-xr-x root/root         0 2024-08-05 11:19 ./var/lib/irods/scripts/irods/
drwxr-xr-x root/root         0 2024-08-05 11:19 ./var/lib/irods/scripts/irods/test/
-rw-r--r-- root/root     31427 2024-08-02 13:46 ./var/lib/irods/scripts/irods/test/test_irods_auth_plugin_pam_interactive.py
```
Client package for focal:
```
$ dpkg -c irods-auth-plugin-pam-interactive-client_0.1.0-0+4.3.3~focal_amd64.deb 
drwxr-xr-x root/root         0 2024-08-05 11:19 ./usr/
drwxr-xr-x root/root         0 2024-08-05 11:19 ./usr/lib/
drwxr-xr-x root/root         0 2024-08-05 11:19 ./usr/lib/irods/
drwxr-xr-x root/root         0 2024-08-05 11:19 ./usr/lib/irods/plugins/
drwxr-xr-x root/root         0 2024-08-05 11:19 ./usr/lib/irods/plugins/auth/
-rw-r--r-- root/root   2423952 2024-08-05 11:12 ./usr/lib/irods/plugins/auth/libirods_auth_plugin-pam_interactive_client.so
```

I've confirmed that the test hook works just like our other plugins on focal. Need to finish building / testing for all our platforms:
 - [x] ubuntu 20.04
 - [x] ubuntu 22.04
 - [x] ubuntu 24.04
 - [x] EL / almalinux 8
 - [x] EL / rockylinux 9
 - [x] debian 11
 - [x] debian 12