### PR TITLE
[irods/irods8451] Bump version requirements and macros for 5.0.0 (main)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,7 @@ include("${IRODS_TARGETS_PATH}")
 
 include(GNUInstallDirs)
 
-if (IRODS_VERSION VERSION_LESS 4.90.0)
+if (IRODS_VERSION VERSION_LESS 5.0.0)
 	include(UseLibCXX)
 	set(IRODS_AUTHENTICATION_PLUGINS_DIRECTORY "${IRODS_PLUGINS_DIRECTORY}/auth")
 else()
@@ -94,7 +94,7 @@ list(APPEND CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION "${CPACK_PACKAGING_INS
 
 list(APPEND CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION "${CPACK_PACKAGING_INSTALL_PREFIX}${IRODS_PLUGINS_DIRECTORY}")
 
-if (${IRODS_VERSION} VERSION_GREATER_EQUAL "4.90.0")
+if (${IRODS_VERSION} VERSION_GREATER_EQUAL "5.0.0")
 	list(APPEND CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION "${CPACK_PACKAGING_INSTALL_PREFIX}${IRODS_PLUGINS_DIRECTORY}/authentication")
 else()
 	list(APPEND CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION "${CPACK_PACKAGING_INSTALL_PREFIX}${IRODS_PLUGINS_DIRECTORY}/auth")
@@ -122,16 +122,16 @@ string(TOUPPER "${project_component_part}-server" irods_plugin_package_server_co
 
 set(CPACK_DEBIAN_${irods_plugin_package_client_component}_PACKAGE_NAME "${PLUGIN_PACKAGE_NAME}-client")
 set(CPACK_DEBIAN_${irods_plugin_package_client_component}_PACKAGE_DEPENDS "irods-runtime (= ${IRODS_VERSION}), libc6")
-set(CPACK_DEBIAN_${irods_plugin_package_client_component}_PACKAGE_BREAKS "${PLUGIN_PACKAGE_NAME} (<< 4.90.0.0-1~), irods-auth-interactive-pam (<< 4.90.0.0-1~)")
-set(CPACK_DEBIAN_${irods_plugin_package_client_component}_PACKAGE_REPLACES "${PLUGIN_PACKAGE_NAME} (<< 4.90.0.0-1~), irods-auth-interactive-pam (<< 4.90.0.0-1~)")
+set(CPACK_DEBIAN_${irods_plugin_package_client_component}_PACKAGE_BREAKS "${PLUGIN_PACKAGE_NAME} (<< 5.0.0.0-1~), irods-auth-interactive-pam (<< 5.0.0.0-1~)")
+set(CPACK_DEBIAN_${irods_plugin_package_client_component}_PACKAGE_REPLACES "${PLUGIN_PACKAGE_NAME} (<< 5.0.0.0-1~), irods-auth-interactive-pam (<< 5.0.0.0-1~)")
 
 set(CPACK_RPM_${irods_plugin_package_client_component}_PACKAGE_NAME "${PLUGIN_PACKAGE_NAME}-client")
 set(CPACK_RPM_${irods_plugin_package_client_component}_PACKAGE_REQUIRES "irods-runtime = ${IRODS_VERSION}")
 
 set(CPACK_DEBIAN_${irods_plugin_package_server_component}_PACKAGE_NAME "${PLUGIN_PACKAGE_NAME}-server")
 set(CPACK_DEBIAN_${irods_plugin_package_server_component}_PACKAGE_DEPENDS "irods-server (= ${IRODS_VERSION}), ${CPACK_DEBIAN_${irods_plugin_package_client_component}_PACKAGE_NAME} (= ${CPACK_PACKAGE_VERSION}-${CPACK_DEBIAN_PACKAGE_RELEASE}), libpam0g")
-set(CPACK_DEBIAN_${irods_plugin_package_server_component}_PACKAGE_BREAKS "${PLUGIN_PACKAGE_NAME} (<< 4.90.0.0-1~), irods-auth-interactive-pam (<< 4.90.0.0-1~)")
-set(CPACK_DEBIAN_${irods_plugin_package_server_component}_PACKAGE_REPLACES "${PLUGIN_PACKAGE_NAME} (<< 4.90.0.0-1~), irods-auth-interactive-pam (<< 4.90.0.0-1~)")
+set(CPACK_DEBIAN_${irods_plugin_package_server_component}_PACKAGE_BREAKS "${PLUGIN_PACKAGE_NAME} (<< 5.0.0.0-1~), irods-auth-interactive-pam (<< 5.0.0.0-1~)")
+set(CPACK_DEBIAN_${irods_plugin_package_server_component}_PACKAGE_REPLACES "${PLUGIN_PACKAGE_NAME} (<< 5.0.0.0-1~), irods-auth-interactive-pam (<< 5.0.0.0-1~)")
 set(CPACK_DEBIAN_${irods_plugin_package_server_component}_PACKAGE_CONTROL_EXTRA "${CMAKE_SOURCE_DIR}/packaging/postinst;")
 
 set(CPACK_RPM_${irods_plugin_package_server_component}_PACKAGE_NAME "${PLUGIN_PACKAGE_NAME}-server")

--- a/plugin/src/main.cpp
+++ b/plugin/src/main.cpp
@@ -84,7 +84,7 @@ namespace
     using log_pam = irods::experimental::log::logger<pam_interactive_auth_plugin_logging_category>;
     namespace fs = boost::filesystem;
 
-#if IRODS_VERSION_INTEGER < 4090000
+#if IRODS_VERSION_INTEGER < 5000000
     // We could use irods::KW_CFG_PLUGIN_TYPE_AUTHENTICATION here, but its value is "auth" (not "authentication") in
     // historical versions of the iRODS server. This is preserved to maintain compatibility with those versions.
     constexpr const char* AUTHENTICATION_CONFIG_KW = "authentication";
@@ -92,7 +92,7 @@ namespace
 
     auto get_pam_checker_program() -> const fs::path&
     {
-#if IRODS_VERSION_INTEGER < 4090000
+#if IRODS_VERSION_INTEGER < 5000000
         static const auto pam_checker{
             irods::get_irods_default_plugin_directory() / "auth" / "pam_handshake_auth_check"};
 #else
@@ -635,7 +635,7 @@ namespace irods
         constexpr const char* KW_CFG_PAM_INTERACTIVE_INSECURE_MODE = "insecure_mode";
         static const auto config_path = irods::configuration_parser::key_path_t{
             irods::KW_CFG_PLUGIN_CONFIGURATION,
-#if IRODS_VERSION_INTEGER < 4090000
+#if IRODS_VERSION_INTEGER < 5000000
             AUTHENTICATION_CONFIG_KW,
 #else
             irods::KW_CFG_PLUGIN_TYPE_AUTHENTICATION,
@@ -668,7 +668,7 @@ namespace irods
         constexpr const char* KW_CFG_PAM_INTERACTIVE_PAM_STACK_NAME = "pam_stack_name";
         static const auto config_path = irods::configuration_parser::key_path_t{
             irods::KW_CFG_PLUGIN_CONFIGURATION,
-#if IRODS_VERSION_INTEGER < 4090000
+#if IRODS_VERSION_INTEGER < 5000000
             AUTHENTICATION_CONFIG_KW,
 #else
             irods::KW_CFG_PLUGIN_TYPE_AUTHENTICATION,


### PR DESCRIPTION
As titled. Not 100% sure about some of these, because these look slightly different than most of the other version bumps: notably, the preprocessor stuff as well as the package name stuff. Does it make sense to bump it like this?