### PR TITLE
iRODS 5 - package dependency updates, tests, and changelog preparation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ and this project **only** adheres to the following _(as defined at [Semantic Ver
 > - MINOR version when you add functionality in a backward compatible manner
 > - PATCH version when you make backward compatible bug fixes
 
+## [0.1.2] - 2025-XX-XX
+
+This release makes the plugin compatible with iRODS 5.0.0.
+
+### Fixed
+
+- Return error on failure to authenticate (#66).
+- Update package dependencies for iRODS 5.0.0 (#71).
+
 ## [0.1.1] - 2025-03-04
 
 This release addresses issues with packaging and availability. There are no functional changes to the plugin's implementation.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,8 @@ endif()
 list(INSERT CMAKE_MODULE_PATH 0 "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules")
 
 set(IRODS_MINIMUM_VERSION "4.3.1")
-find_package(IRODS "${IRODS_MINIMUM_VERSION}" REQUIRED)
+set(IRODS_MAXIMUM_VERSION "6.0.0")
+find_package(IRODS "${IRODS_MINIMUM_VERSION}...<${IRODS_MAXIMUM_VERSION}" REQUIRED)
 set(IRODS_PLUGIN_VERSION "0.1.2")
 
 set(IRODS_PACKAGE_REVISION "0")
@@ -62,10 +63,8 @@ endif()
 find_package(Threads REQUIRED)
 find_package(OpenSSL REQUIRED COMPONENTS Crypto SSL)
 find_package(nlohmann_json "3.6.1" REQUIRED)
-find_package(fmt "8.1.1"
+find_package(fmt "8.1.1" REQUIRED
 	HINTS "${IRODS_EXTERNALS_FULLPATH_FMT}")
-find_package(spdlog "1.9.2"
-	HINTS "${IRODS_EXTERNALS_FULLPATH_SPDLOG}")
 find_package(PAM REQUIRED)
 
 add_subdirectory(common)

--- a/irods_consortium_continuous_integration_build_hook.py
+++ b/irods_consortium_continuous_integration_build_hook.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import glob
 import multiprocessing
 import optparse
@@ -32,17 +30,8 @@ def install_building_dependencies(externals_directory):
     # externals are being supplied via externals_directory, only the externals packages which exist in that directory
     # will be installed.
     externals_list = [
-        'irods-externals-avro-libcxx1.11.0-3',
-        'irods-externals-boost-libcxx1.81.0-1',
-        'irods-externals-clang-runtime13.0.1-0',
-        'irods-externals-clang13.0.1-0',
-        'irods-externals-cppzmq4.8.1-1',
-        'irods-externals-fmt-libcxx8.1.1-1',
-        'irods-externals-json3.10.4-0',
-        'irods-externals-libarchive3.5.2-0',
-        'irods-externals-nanodbc-libcxx2.13.0-2',
-        'irods-externals-spdlog-libcxx1.9.2-2',
-        'irods-externals-zeromq4-1-libcxx4.1.8-1'
+        'irods-externals-boost1.81.0-2',
+        'irods-externals-clang16.0.6-0'
     ]
     if externals_directory == 'None' or externals_directory is None:
         irods_python_ci_utilities.install_irods_core_dev_repository()

--- a/packaging/test_irods_auth_plugin_pam_interactive.py
+++ b/packaging/test_irods_auth_plugin_pam_interactive.py
@@ -864,7 +864,7 @@ class test_pam_stack_configuration(unittest.TestCase):
 			IrodsController().reload_configuration()
 
 			# Try to authenticate and observe success because this stack always allows authentication.
-			self.auth_session.assert_icommand(['iinit'])
+			self.auth_session.assert_icommand(['iinit'], 'STDOUT', ['Connecting as'])
 
 			# Now set the pam_stack_name to always-deny, which will always cause authentication to fail.
 			server_config['plugin_configuration']['authentication']['pam_interactive']['pam_stack_name'] = 'always-deny'
@@ -889,7 +889,7 @@ class test_pam_stack_configuration(unittest.TestCase):
 			IrodsController().reload_configuration()
 
 			# Try to authenticate and observe success.
-			self.auth_session.assert_icommand(['iinit'])
+			self.auth_session.assert_icommand(['iinit'], 'STDOUT', ['Connecting as'])
 
 	def test_authenticating_with_pam_stack_name_as_non_string_fails(self):
 		server_config_path = paths.server_config_path()


### PR DESCRIPTION
Tests pass against iRODS 5.

Will open an issue about the comment above the `externals_list` in the build hook.